### PR TITLE
feat: add new request max limit param ('--req_max')

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN go build -v -o . ./...
 ENV GMOCKY_PORT 3333
 ENV GMOCKY_HOME /usr/src/app/gmocky-2/data
 ENV GMOCKY_CERT /usr/src/app/gmocky-2/cert
+# -1 / unlimited
+ENV GMOCKY_REQ_MAX_LIMIT -1
 
  # if true the *.crt and *.key files must be provided
 ENV GMOCKY_SSL false

--- a/README.md
+++ b/README.md
@@ -45,18 +45,19 @@ $ curl http://localhost:3333/
 
 Deploy it as a service or use it directly in your development for integration tests.
 
-| Option | Value                       | Default | Description |
-| ---    | ---                         | ---     | ---
-| --home | /home/{user}/data/gmocky-v2 | .       | Define the working directory or use `$GMOCKY_HOME` env
-| --port | 3333                        | 3333    | Define a specific port or use `$GMOCKY_PORT` env
+| Option    | Env                     | Value                       | Default          | Description |
+| ---       | ---                     | ---                         | ---              | ---
+| --home    | GMOCKY_HOME             | /home/{user}/app/gmocky-v2  | .                | Define the working directory
+| --port    | GMOCKY_PORT             | 3333                        | 3333             | Define a specific port
+| --req_max | GMOCKY_REQ_MAX_LIMIT    | 100                         | -1 (`unlimited`) | Define the max limit of the mocked requests
+| --ssl     | GMOCKY_SSL              | true                        | false            | Enable SSL/Tls HTTP server (need to provide certificate)
+| --cert    | GMOCKY_CERT             | /home/{user}/app/gmocky-v2  | 3333             | Define the certificate directory to contain (`gmocky.cert` and `gmocky.key`)
 
 1. Start the server
 
 ```bash
 $ cd cmd/httpserver
-$ ./httpserver --home /home/{user}/data/gmocky-v2 --port 3333
-#$ docker run -it --rm -p 3333:3333 -e GMOCKY_HOME=/home/{user}/data/gmocky-v2 -e GMOCKY_PORT=3333 gmocky-v2
-
+$ ./httpserver --home /home/{user}/app/gmocky-v2 --port 3333
        ______        __  ___ ____   ______ __ ____  __      __   _____  ______ ____  _    __ ______ ____
       / ____/       /  |/  // __ \ / ____// //_/\ \/ /    _/_/  / ___/ / ____// __ \| |  / // ____// __ \
      / / __ ______ / /|_/ // / / // /    / ,<    \  /   _/_/    \__ \ / __/  / /_/ /| | / // __/  / /_/ /
@@ -112,7 +113,7 @@ Run the HTTP server in SSL/Tls (`https`) mode with certificate.
 
 ```bash
 $ ./httpserver \
-  --home /home/{user}/data/gmocky-v2 \
+  --home /home/{user}/app/gmocky-v2 \
   --port 3333 \
   --ssl true \
   --cert {certificate-path-directory}
@@ -261,6 +262,18 @@ ok  	github.com/joakim-ribier/gmocky-v2/internal/server	2.181s	coverage: 91.0% o
 ```
 
 ## Docker
+
+### Pull and Run
+
+```bash
+# pull the last version
+$ docker pull joakimribier/gmocky-v2:latest
+
+# run the docker image
+$ docker run -it --rm -p 3333:3333 -e GMOCKY_PORT=3333 -e GMOCKY_SSL=true \
+  -v /home/{user}/app/gmocky-v2/data:/usr/src/app/gmocky-2/data \
+  -v /home/{user}/app/gmocky-v2/cert:/usr/src/app/gmocky-2/cert:ro joakimribier/gmocky-v2
+```
 
 ### Build
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
-	github.com/joakim-ribier/go-utils v0.0.0-20240731193931-b7b805a5ff92
+	github.com/joakim-ribier/go-utils v0.0.0-20240801182449-4e195b0d0998
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/joakim-ribier/go-utils v0.0.0-20240731172845-980a8f028c67 h1:CzDAQmvM
 github.com/joakim-ribier/go-utils v0.0.0-20240731172845-980a8f028c67/go.mod h1:ziQiPctIQVMcYF7yxo3MC7ei/kBc+W5PY82gc7pstmU=
 github.com/joakim-ribier/go-utils v0.0.0-20240731193931-b7b805a5ff92 h1:mHDpdsdFpnSvOvDygC1F2uRgyXObUywUlvkIhWwTeLc=
 github.com/joakim-ribier/go-utils v0.0.0-20240731193931-b7b805a5ff92/go.mod h1:ziQiPctIQVMcYF7yxo3MC7ei/kBc+W5PY82gc7pstmU=
+github.com/joakim-ribier/go-utils v0.0.0-20240801182449-4e195b0d0998 h1:MsNXcoFt3vbo8s/lHWUh/5rhrUE2p9ZwrN4sbwlI4+s=
+github.com/joakim-ribier/go-utils v0.0.0-20240801182449-4e195b0d0998/go.mod h1:ziQiPctIQVMcYF7yxo3MC7ei/kBc+W5PY82gc7pstmU=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/context.go
+++ b/internal/context.go
@@ -12,10 +12,11 @@ const LOGO = `
 `
 
 var GMOCKY_HOME = os.Getenv("GMOCKY_HOME")
+var GMOCKY_REQ_MAX_LIMIT = -1
 
 var GMOCKY_PORT = os.Getenv("GMOCKY_PORT")
 
-var GMOCKY_SSL = os.Getenv("GMOCKY_SSL")
+var GMOCKY_SSL = false
 var GMOCKY_CERT_DIRECTORY = os.Getenv("GMOCKY_CERT")
 var GMOCKY_CERT_FILENAME = "gmocky.crt"
 var GMOCKY_PEM_FILENAME = "gmocky.key"


### PR DESCRIPTION
Add new param to limit the requests number on the server (mode demo for example)

| Option    | Env                     | Value                       | Default          | Description |
| ---       | ---                     | ---                         | ---              | ---
| --req_max | GMOCKY_REQ_MAX_LIMIT    | 100                         | -1 (`unlimited`) | Define the max limit of the mocked requests