### PR TITLE
feat: change the way to post a new mocked request ('metadata' in the url;'content' directly in the body)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ go.work.sum
 
 .DS_Store
 cmd/httpserver/httpserver
+cmd/httpserver/application.log
+cmd/httpserver/remote-addr.json
+cmd/httpserver/requests/
 cert/mockapic*
 mockapic

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ The first one simulate a real response of the external API service which returns
 
 ```bash
 $ curl -X POST 'http://localhost:3333/v1/new?status=200&contentType=application%2Fjson&charset=UTF-8&domain=github.com%2Fjoakim-ribier&project=mockapic' \
---header 'Content-Type: application/json' \
 --data '{
   "timestamp":1725967696,
   "rates":{

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -53,6 +53,11 @@ func main() {
 		"req_max", internal.MOCKAPIC_REQ_MAX_LIMIT,
 	)
 
+	err = os.MkdirAll(internal.MOCKAPIC_HOME+"/requests", os.ModePerm)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
 	httpServer := server.NewHTTPServer(
 		stringsutil.OrElse(internal.MOCKAPIC_PORT, "3333"),
 		internal.MOCKAPIC_SSL,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -49,7 +49,9 @@ func (s HTTPServer) Listen() error {
 
 	handleFunc := func(method, pattern string, handle func(w http.ResponseWriter, r *http.Request)) {
 		server.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
-			s.logger.Info("request", "uri", r.RequestURI, "method", r.Method)
+			remoteAddr := s.findRemoteAddr(r.RemoteAddr)
+			s.logger.Info("request", "uri", r.RequestURI, "method", r.Method, "remoteAddr", remoteAddr)
+
 			if r.Method != method {
 				w.WriteHeader(404)
 				return
@@ -265,7 +267,7 @@ func (s HTTPServer) addNewMock(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	newUUID, err := s.mocker.New(body)
+	newUUID, err := s.mocker.New(r.URL.Query(), body)
 	if err != nil {
 		s.logger.Error(err, "error to create new mock", "uri", r.RequestURI, "body", body)
 		writeError(w, err)

--- a/internal/server/response_test.go
+++ b/internal/server/response_test.go
@@ -35,7 +35,7 @@ func TestWrite(t *testing.T) {
 		Status:      200,
 		ContentType: "text/plain",
 		Charset:     "UTF-8",
-		Body:        "Hello World",
+		Body:        []byte("Hello World"),
 		Headers:     map[string]string{"x-language": "golang"},
 	}
 
@@ -66,7 +66,7 @@ func TestWriteWithMaxDelay(t *testing.T) {
 		Status:      200,
 		ContentType: "text/plain",
 		Charset:     "UTF-8",
-		Body:        "Hello World",
+		Body:        []byte("Hello World"),
 		Headers:     map[string]string{"x-language": "golang"},
 	}
 


### PR DESCRIPTION
Change the way to post a new mock request. It is simpler and clearer to put the content of the mocked request directly in the body of the POST request and metadata in the URL.

```bash
$ curl -X POST 'http://localhost:3333/v1/new?status=200&contentType=application%2Fjson&charset=UTF-8&domain=github.com%2Fjoakim-ribier&project=mockapic' \
--header 'Content-Type: application/json' \
--data '{
  "timestamp":1725967696,
  "rates":{
    "EUR":1,
    "GBP":0.842772,
    "KZT":527.025041,
    "USD":1.103546
  }
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   408  100    48  100   360  13892   101k --:--:-- --:--:-- --:--:--  132k
{
  "uuid": "c1403100-3aa0-484f-8e0f-f2c1db80f371"
}
```