### PR TITLE
feat: define an custom 'uri' endpoint for mocked request

### DIFF
--- a/internal/mock_test.go
+++ b/internal/mock_test.go
@@ -53,7 +53,7 @@ func TestGetWithBadRequest(t *testing.T) {
 
 	err := iosutil.Write([]byte(mockedRequest), file)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	r, err := NewMock(workingDirectory, nil, *logger).Get("{id}")
@@ -70,7 +70,7 @@ func TestGet(t *testing.T) {
 
 	r, err := NewMock(workingDirectory, nil, *logger).Get(mockedRequest.Id)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if !r.Equals(mockedRequest) {
@@ -97,7 +97,7 @@ func TestGetFromLoadedMockedRequest(t *testing.T) {
 
 	r, err := NewMock(workingDirectory, []PredefinedMockedRequest{{MockedRequest: *mockedRequest}}, *logger).Get(mockedRequest.Id)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	mockedRequest.Body64 = []byte("Hello World")
@@ -125,7 +125,7 @@ func TestList(t *testing.T) {
 
 	r, err := NewMock(workingDirectory, nil, *logger).List()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if !slicesutil.ExistT[MockedRequestLight](r, func(ml MockedRequestLight) bool {
@@ -154,7 +154,7 @@ func TestListWithPredefinedMockedRequests(t *testing.T) {
 
 	r, err := NewMock(workingDirectory, []PredefinedMockedRequest{{MockedRequest: mockedRequest}}, *logger).List()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if !slicesutil.ExistT[MockedRequestLight](r, func(ml MockedRequestLight) bool { return ml.Id == mockedRequest.Id }) {
@@ -235,14 +235,14 @@ func TestNew(t *testing.T) {
 	}
 	reqBody := "Hello World"
 
-	id, err := NewMock(workingDirectory, nil, *logger).New(reqParams, []byte(reqBody))
+	newMocked, err := NewMock(workingDirectory, nil, *logger).New(reqParams, []byte(reqBody))
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
-	mock, err := NewMock(workingDirectory, nil, *logger).Get(*id)
+	mock, err := NewMock(workingDirectory, nil, *logger).Get(newMocked.Id)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	expected := MockedRequest{


### PR DESCRIPTION
For `StrangeBee` (to test `Ms Graph API` 🔥 🚀 ) needs set a 'uri' field for mocked request to custom the endpoint.

```
$ curl -X POST 'http://localhost:3333/v1/new?status=200&contentType=application%2Fjson&charset=UTF-8&uri=my-uri \
--data '{
  "timestamp":1725967696,
  "rates":{
    "EUR":1,
    "GBP":0.842772,
    "KZT":527.025041,
    "USD":1.103546
  }
}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   408  100    48  100   360  13892   101k --:--:-- --:--:-- --:--:--  132k
{
  "id": "c1403100-3aa0-484f-8e0f-f2c1db80f371",
  "_links": {
    "raw": "http://localhost:3333/v1/raw/c1403100-3aa0-484f-8e0f-f2c1db80f371",
    "self": "http://localhost:3333/v1/c1403100-3aa0-484f-8e0f-f2c1db80f371"
  }
}
```
```
$ curl -GET 'http://localhost:3333/v1/my-uri' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    89  100    89    0     0   1226      0 --:--:-- --:--:-- --:--:--  1236
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=UTF-8
< Domain: github.com/joakim-ribier
< Project: mockapic
{
  "timestamp": 1725967696,
  "rates": {
    "EUR": 1,
    "GBP": 0.842772,
    "KZT": 527.025041,
    "USD": 1.103546
  }
}
```