### PR TITLE
feat: call a mocked request on [POST] method

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,16 @@ $ ./httpserver \
 
 List APIs available
 
-| Method | Endpoint                              | Description |
-| ---    | ---                                   | ---
-| GET    | /                                     | Get info
-| GET    | /static/content-types                 | Get allowed content types
-| GET    | /static/charsets                      | Get allowed charsets
-| GET    | /static/status-codes                  | Get allowed status codes
-| GET    | [/v1/{id}](#get-mocked-request)       | Get a mocked request
-| GET    | [/v1/raw/{id}](#raw-mocked-request)   | Get a raw mocked request
-| GET    | [/v1/list](#list-requests)            | Get the list of all mocked requests
-| POST   | [/v1/new](#create-new-mocked-request) | Create a new mocked request
+| Method   | Endpoint                              | Description                         | Status code
+| ---      | ---                                   | ---                                 | ---
+| GET      | /                                     | Get info                            | 200 OK
+| GET      | /static/content-types                 | Get allowed content types           | 200 OK
+| GET      | /static/charsets                      | Get allowed charsets                | 200 OK
+| GET      | /static/status-codes                  | Get allowed status codes            | 200 OK
+| GET+POST | [/v1/{id}](#get-mocked-request)       | Get a mocked request                | 200 OK
+| GET      | [/v1/raw/{id}](#raw-mocked-request)   | Get a raw mocked request            | 200 OK
+| GET      | [/v1/list](#list-requests)            | Get the list of all mocked requests | 200 OK
+| POST     | [/v1/new](#create-new-mocked-request) | Create a new mocked request         | 201 Created
 
 #### Create New Mocked Request
 


### PR DESCRIPTION
Add the possibility to call a mocked request on GET and POST methods.

```
GET ~/v1/{id}
POST ~/v1/{id}
```