### PR TITLE
feat: handle a mocked request on GET+POST methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,16 +196,16 @@ $ ./httpserver \
 
 List APIs available
 
-| Method | Endpoint                              | Description |
-| ---    | ---                                   | ---
-| GET    | /                                     | Get info
-| GET    | /static/content-types                 | Get allowed content types
-| GET    | /static/charsets                      | Get allowed charsets
-| GET    | /static/status-codes                  | Get allowed status codes
-| GET    | [/v1/{id}](#get-mocked-request)       | Get a mocked request
-| GET    | [/v1/raw/{id}](#raw-mocked-request)   | Get a raw mocked request
-| GET    | [/v1/list](#list-requests)            | Get the list of all mocked requests
-| POST   | [/v1/new](#create-new-mocked-request) | Create a new mocked request
+| Method   | Endpoint                              | Description                         | Status code
+| ---      | ---                                   | ---                                 | ---
+| GET      | /                                     | Get info                            | 200 OK
+| GET      | /static/content-types                 | Get allowed content types           | 200 OK
+| GET      | /static/charsets                      | Get allowed charsets                | 200 OK
+| GET      | /static/status-codes                  | Get allowed status codes            | 200 OK
+| GET+POST | [/v1/{id}](#get-mocked-request)       | Get a mocked request                | 200 OK
+| GET      | [/v1/raw/{id}](#raw-mocked-request)   | Get a raw mocked request            | 200 OK
+| GET      | [/v1/list](#list-requests)            | Get the list of all mocked requests | 200 OK
+| POST     | [/v1/new](#create-new-mocked-request) | Create a new mocked request         | 201 Created
 
 #### Create New Mocked Request
 

--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -15,13 +15,22 @@ import (
 	"github.com/joakim-ribier/mockapic/internal/server"
 )
 
+var MOCKAPIC_HOME = os.Getenv("MOCKAPIC_HOME")
+var MOCKAPIC_PORT = os.Getenv("MOCKAPIC_PORT")
+var MOCKAPIC_REQUEST = func() string {
+	return MOCKAPIC_HOME + "/requests"
+}
+var MOCKAPIC_REQ_PREDEFINED_FILE = func() string {
+	return MOCKAPIC_HOME + "/mockapic.json"
+}
+
 func main() {
 	args := slicesutil.ToMap(os.Args[1:])
 
 	if arg, ok := args["--home"]; ok {
-		internal.MOCKAPIC_HOME = arg
+		MOCKAPIC_HOME = arg
 	}
-	if _, err := os.Open(internal.MOCKAPIC_HOME); err != nil {
+	if _, err := os.Open(MOCKAPIC_HOME); err != nil {
 		log.Fatalf("'--home' parameter must be a valid directory.\n%v", err)
 	}
 
@@ -29,7 +38,7 @@ func main() {
 		internal.MOCKAPIC_REQ_MAX_LIMIT = stringsutil.Int(arg, -1)
 	}
 	if arg, ok := args["--port"]; ok {
-		internal.MOCKAPIC_PORT = arg
+		MOCKAPIC_PORT = arg
 	}
 	if arg, ok := args["--cert"]; ok {
 		internal.MOCKAPIC_CERT_DIRECTORY = arg
@@ -37,45 +46,45 @@ func main() {
 	if arg, ok := args["--ssl"]; ok {
 		internal.MOCKAPIC_SSL = stringsutil.Bool(arg)
 		if internal.MOCKAPIC_SSL && internal.MOCKAPIC_CERT_DIRECTORY == "" {
-			internal.MOCKAPIC_CERT_DIRECTORY = internal.MOCKAPIC_HOME
+			internal.MOCKAPIC_CERT_DIRECTORY = MOCKAPIC_HOME
 		}
 	}
 
-	logger, err := logsutil.NewLogger(internal.MOCKAPIC_HOME+"/application.log", "mockapic")
+	logger, err := logsutil.NewLogger(MOCKAPIC_HOME+"/application.log", "mockapic")
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
 
 	logger.Info(internal.LOGO,
-		"home", internal.MOCKAPIC_HOME,
-		"port", internal.MOCKAPIC_PORT,
+		"home", MOCKAPIC_HOME,
+		"port", MOCKAPIC_PORT,
 		"ssl", internal.MOCKAPIC_SSL,
 		"req_max", internal.MOCKAPIC_REQ_MAX_LIMIT,
 	)
 
-	err = os.MkdirAll(internal.MOCKAPIC_REQUEST(), os.ModePerm)
+	err = os.MkdirAll(MOCKAPIC_REQUEST(), os.ModePerm)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
 
 	predefinedMockedRequests := []internal.PredefinedMockedRequest{}
-	data, err := iosutil.Load(internal.MOCKAPIC_REQ_PREDEFINED_FILE())
+	data, err := iosutil.Load(MOCKAPIC_REQ_PREDEFINED_FILE())
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("file {%s} not found", internal.MOCKAPIC_REQ_PREDEFINED_FILE()))
+		logger.Error(err, fmt.Sprintf("file {%s} not found", MOCKAPIC_REQ_PREDEFINED_FILE()))
 	} else {
 		predefinedMockedRequests, err = jsonsutil.Unmarshal[[]internal.PredefinedMockedRequest](data)
 		if err != nil {
-			logger.Error(err, fmt.Sprintf("file {%s} cannot be parsed", internal.MOCKAPIC_REQ_PREDEFINED_FILE()))
+			logger.Error(err, fmt.Sprintf("file {%s} cannot be parsed", MOCKAPIC_REQ_PREDEFINED_FILE()))
 		}
 	}
 
-	mock := internal.NewMock(internal.MOCKAPIC_REQUEST(), predefinedMockedRequests, *logger)
+	mock := internal.NewMock(MOCKAPIC_REQUEST(), predefinedMockedRequests, *logger)
 
 	httpServer := server.NewHTTPServer(
-		stringsutil.OrElse(internal.MOCKAPIC_PORT, "3333"),
+		stringsutil.OrElse(MOCKAPIC_PORT, "3333"),
 		internal.MOCKAPIC_SSL,
 		internal.MOCKAPIC_CERT_DIRECTORY,
-		internal.MOCKAPIC_HOME,
+		MOCKAPIC_HOME,
 		mock,
 		*logger)
 

--- a/internal/context.go
+++ b/internal/context.go
@@ -16,17 +16,7 @@ const LOGO = `
                     https://github.com/joakim-ribier/mockapic
 `
 
-var MOCKAPIC_HOME = os.Getenv("MOCKAPIC_HOME")
-var MOCKAPIC_REQUEST = func() string {
-	return MOCKAPIC_HOME + "/requests"
-}
-var MOCKAPIC_REQ_PREDEFINED_FILE = func() string {
-	return MOCKAPIC_HOME + "/mockapic.json"
-}
-
 var MOCKAPIC_REQ_MAX_LIMIT = stringsutil.Int(os.Getenv("MOCKAPIC_REQ_MAX_LIMIT"), -1)
-
-var MOCKAPIC_PORT = os.Getenv("MOCKAPIC_PORT")
 
 var MOCKAPIC_SSL = stringsutil.Bool(os.Getenv("MOCKAPIC_SSL"))
 var MOCKAPIC_CERT_DIRECTORY = os.Getenv("MOCKAPIC_CERT")

--- a/internal/mock_test.go
+++ b/internal/mock_test.go
@@ -232,6 +232,7 @@ func TestNew(t *testing.T) {
 		"charset":     {"UTF-8"},
 		"x-language":  {"golang"},
 		"x-domain":    {"github.com"},
+		"path":        {"/my-path"},
 	}
 	reqBody := "Hello World"
 
@@ -252,6 +253,7 @@ func TestNew(t *testing.T) {
 				ContentType: "text/plain",
 				Charset:     "UTF-8",
 				Headers:     map[string]string{"x-language": "golang", "x-domain": "github.com"},
+				Path:        "/my-path",
 			},
 		},
 		Body64: []byte("Hello World"),

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -91,10 +91,28 @@ func TestMain(m *testing.M) {
 	os.Exit(exitVal)
 }
 
-// TestListen calls HTTPServer.Listen(),
+// TestListenEndpoints calls HTTPServer.Listen(),
 // checking for a valid return value.
-func TestListen(t *testing.T) {
-	httpServer := NewHTTPServer("3334", false, "", workingDirectory, &MockerTest{}, *logger)
+func TestListenEndpoints(t *testing.T) {
+	mockedRequest := &internal.MockedRequest{
+		MockedRequestLight: internal.MockedRequestLight{
+			Id: "{id}",
+			MockedRequestHeader: internal.MockedRequestHeader{
+				Status:      200,
+				ContentType: "text/plain",
+				Charset:     "UTF-8",
+				Headers:     map[string]string{},
+			},
+		},
+		Body: "Hello World",
+	}
+
+	mockerTest := &MockerTest{
+		mockResponse:       mockedRequest,
+		mockResponseLights: []internal.MockedRequestLight{mockedRequest.MockedRequestLight}}
+
+	baseURL := "http://localhost:3334"
+	httpServer := NewHTTPServer("3334", false, "", workingDirectory, mockerTest, *logger)
 
 	go func() {
 		err := httpServer.Listen()
@@ -104,19 +122,24 @@ func TestListen(t *testing.T) {
 	}()
 	time.Sleep(100 * time.Millisecond)
 
-	req, _ := httpsutil.NewHttpRequest("http://localhost:3334/", "")
-	resp, _ := req.Call()
-
-	if resp.StatusCode != 200 {
-		t.Fatalf(`result: {%v} but expected {%v}`, resp.StatusCode, 200)
+	assertReq := func(method, url, body string, expectedCodeResult int) {
+		req, _ := httpsutil.NewHttpRequest(baseURL+url, body)
+		resp, _ := req.Method(method).Call()
+		if resp.StatusCode != expectedCodeResult {
+			t.Fatalf(`result: [%s] %s => {%v} but expected {%v}`, method, url, resp.StatusCode, expectedCodeResult)
+		}
 	}
 
-	// testing '404' if bad endpoint is called
-	req, _ = httpsutil.NewHttpRequest("http://localhost:3334/", "")
-	resp, _ = req.Method("POST").Call()
-	if resp.StatusCode != 404 {
-		t.Fatalf(`result: {%v} but expected {%v}`, resp.StatusCode, 200)
-	}
+	assertReq(http.MethodGet, "", "", http.StatusOK)
+	assertReq(http.MethodGet, "/static/content-types", "", http.StatusOK)
+	assertReq(http.MethodGet, "/static/charsets", "", http.StatusOK)
+	assertReq(http.MethodGet, "/static/status-codes", "", http.StatusOK)
+	assertReq(http.MethodGet, "/v1/{id}", "", http.StatusOK)
+	assertReq(http.MethodPost, "/v1/{id}", "", http.StatusOK)
+	assertReq(http.MethodGet, "/v1/{wrong-id}", "", http.StatusNotFound)
+	assertReq(http.MethodGet, "/v1/raw/{id}", "", http.StatusOK)
+	assertReq(http.MethodGet, "/v1/list", "", http.StatusOK)
+	assertReq(http.MethodPost, "/v1/new?status=200&contentType=text/plain&charset=UTF-8", "Hello World", http.StatusCreated)
 }
 
 // TestListen calls HTTPServer.Listen(),
@@ -466,7 +489,7 @@ func TestAddNewEndpoint(t *testing.T) {
 		Body64: []byte("Hello World"),
 	}
 
-	if res.Status != "200 OK" ||
+	if res.Status != "201 Created" ||
 		string(body) != `{"_links":{"path":"http://localhost:3333/v1/my-path","raw":"http://localhost:3333/v1/raw/{id}","self":"http://localhost:3333/v1/{id}"},"id":"{id}"}` ||
 		!mocker.mockResponse.Equals(expected) ||
 		!mocker.clean ||


### PR DESCRIPTION
Updates:

1. handle a mocked request on GET+POST: `GET+POST ~/v1/{id}`
2. fix `~/v1/new` code status response (~~200 OK~~ => `201 Created`)