### PR TITLE
feat: small updates for mockapic-ui :tada: (add ~/status endpoint, and enable cors for localhost requests)

### DIFF
--- a/cmd/httpserver/main.go
+++ b/cmd/httpserver/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/joakim-ribier/go-utils/pkg/genericsutil"
 	"github.com/joakim-ribier/go-utils/pkg/iosutil"
@@ -76,7 +77,7 @@ func main() {
 		*reqMaxLimit,
 		mock,
 		*logger,
-		resources.Version)
+		strings.TrimSuffix(resources.Version, "\n"))
 
 	fmt.Print(internal.LOGO)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakim-ribier/mockapic
 
-go 1.23.7
+go 1.23.8
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/joakim-ribier/go-utils v0.0.0-20240807210644-38116094b686
+	github.com/rs/cors v1.11.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/jedib0t/go-pretty/v6 v6.5.9 h1:ACteMBRrrmm1gMsXe9PSTOClQ63IXDUt03H5U+
 github.com/jedib0t/go-pretty/v6 v6.5.9/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
 github.com/joakim-ribier/go-utils v0.0.0-20240807210644-38116094b686 h1:RmNPNQcWNpgAizxfIpV/ajT9zeJSduDkS9/8X31Ss78=
 github.com/joakim-ribier/go-utils v0.0.0-20240807210644-38116094b686/go.mod h1:jL9aqNowgUnfJ7FtFNCsQ9AdZA/xWSkmvJ+NDNXhThc=
-github.com/joakim-ribier/go-utils v0.0.0-20241224170118-715e427d8efc h1:Vy5btQphxRbPAWgcUm/FsTcZ6N3z1JYGdT4FDweMwE0=
-github.com/joakim-ribier/go-utils v0.0.0-20241224170118-715e427d8efc/go.mod h1:YTlyBrQ1L59sux5RDidYfzMtBSG0HiPvPce4ELZv6bM=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -42,6 +40,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/joakim-ribier/go-utils/pkg/iosutil"
@@ -16,6 +17,7 @@ import (
 	"github.com/joakim-ribier/go-utils/pkg/stringsutil"
 	"github.com/joakim-ribier/mockapic/internal"
 	"github.com/joakim-ribier/mockapic/pkg"
+	"github.com/rs/cors"
 )
 
 var METHODS_ALL = []string{
@@ -103,6 +105,7 @@ func (s HTTPServer) Listen() error {
 	}
 
 	handleFunc(http.MethodGet, "/", s.home)
+	handleFunc(http.MethodGet, "/status", s.status)
 
 	handleFunc(http.MethodGet, "/static/content-types", s.getContentTypes)
 	handleFunc(http.MethodGet, "/static/charsets", s.getCharsets)
@@ -113,16 +116,29 @@ func (s HTTPServer) Listen() error {
 	handleFunc(http.MethodGet, "/v1/list", s.list)
 	handleFunc(http.MethodPost, "/v1/new", s.addNewMock)
 
+	cors := cors.New(cors.Options{
+		AllowOriginFunc: func(origin string) bool {
+			return strings.HasPrefix(origin, "http://localhost:") || strings.HasPrefix(origin, "http://127.0.0.1:")
+		},
+		AllowedMethods:   METHODS_ALL,
+		AllowCredentials: false,
+	})
+	handler := cors.Handler(server)
+
 	if s.ssl.enabled {
 		return http.ListenAndServeTLS(
 			":"+s.Port,
 			s.ssl.crtFile,
 			s.ssl.keyFile,
-			server,
+			handler,
 		)
 	} else {
-		return http.ListenAndServe(":"+s.Port, server)
+		return http.ListenAndServe(":"+s.Port, handler)
 	}
+}
+
+func (s HTTPServer) status(w http.ResponseWriter, r *http.Request) {
+	s.writeResponse(w, r, map[string]any{"version": s.version}, http.StatusOK)
 }
 
 func (s HTTPServer) home(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -189,6 +189,24 @@ func TestRootEndpoint(t *testing.T) {
 }
 
 // ##
+// #### ~/status
+// ##
+
+// TestStatusEndpoint calls HTTPServer.status(http.ResponseWriter, *http.Request),
+// checking for a valid return value.
+func TestStatusEndpoint(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://localhost:3333/status", nil)
+	w := httptest.NewRecorder()
+
+	NewHTTPServer("{port}", NewSSL(false, "", "", ""), workingDirectory, -1, &MockerTest{}, *logger, "v-test").status(w, req)
+
+	_, body := geResultResponse(w, t)
+	if !strings.Contains(string(body), `{"version":"v-test"}`) {
+		t.Fatalf(`result: {%v} but expected {%v}`, string(body), `{"version":"v-test"}`)
+	}
+}
+
+// ##
 // #### ~/static/content-types endpoint
 // ##
 


### PR DESCRIPTION
Small updates for the first version of Mockapic UI.

1. Enable cors for locahost requests
2. Add ~/status endpoint to return the mockapic server version