### PR TITLE
chore: upgade golang to '1.24.4' to fix CVE-2025-22871

### DIFF
--- a/.github/workflows/build_test_and_coverage_reusable.yml
+++ b/.github/workflows/build_test_and_coverage_reusable.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23.4'
+        go-version: '1.24.4'
 
     - name: Build
       run: go build -v ./...
@@ -37,5 +37,5 @@ jobs:
     - name: Check vulnerabilities
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: 1.23.4
+        go-version-input: 1.24.4
         go-package: ./...

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,4 +1,4 @@
-name: Pre-release (Bum the release version)
+name: Pre-release (Bump the release version)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        goversion: 1.23.4
+        goversion: 1.24.4
         project_path: "./cmd/httpserver"
         binary_name: "mockapic"
         extra_files: LICENSE README.md ./pkg/resources/generated-version.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Step 1: Build stage
-FROM golang:1.23.7-alpine AS builder
+FROM golang:1.24.4-alpine AS builder
 
 # source
 RUN mkdir -p /usr/src/app/mockapic

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It's always complicated to test easly your application when it uses external API
 
 It's for all these reasons that I created `Mockapic` (based on the awesome [mocky.io](https://designer.mocky.io/) idea). The main goal is to be able to better test your code on several behaviors when calling external API services.
 
-[Usage](#usage) - [How it works](#how-it-works) - [APIs](#apis) - [Test](#test) - [Docker](#docker) - [CI](#ci) - [Demo](#demo) - [Thanks](#thanks) - [License](#license)
+[Usage](#usage) - [How it works](#how-it-works) - [APIs](#apis) - [Test](#test) - [Release](#release) - [Docker](#docker) - [CI](#ci) - [Demo](#demo) - [Thanks](#thanks) - [License](#license)
 
 ## Usage
 
@@ -320,7 +320,12 @@ ok  	github.com/joakim-ribier/mockapic/internal	1.642s	coverage: 100.0% of state
 ok  	github.com/joakim-ribier/mockapic/internal/server	2.181s	coverage: 91.0% of statements
 ```
 
-## Docker
+## Release
+
+1. Bump the new version with the manual workflow: [Pre-release (Bump the release version)](.github/workflows/pre-release.yml)
+2. Create a new release from [mockapic/releases](https://github.com/joakim-ribier/mockapic/releases) - This action will automatically trigger [Publish binaries and tag Docker image](.github/workflows/release.yml) workflow.
+
+## Docker 
 
 ### Pull and Run
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/joakim-ribier/mockapic
 
-go 1.23.7
+go 1.24.4
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Update to `1.24.4` to fix CVE-2025-22871 :rocket:

https://hub.docker.com/layers/joakimribier/mockapic/v1.0.3/images/sha256-3bd67127d6a8159796e85fbff0384f1e4dc357e3b95b84a8bc6994953bd1796c